### PR TITLE
feat(config): add ready_on_start directive to dynamic block

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can have the following configuration:
 				[show_details yes|true|on]
 				[theme hacker-terminal]
 				[refresh_frequency 2s]
+				[ready_on_start]
 			}
 			blocking {
 				[timeout 1m]

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type DynamicConfiguration struct {
 	ShowDetails      *bool
 	Theme            string
 	RefreshFrequency *time.Duration
+	ReadyOnStart     *bool
 }
 
 type BlockingConfiguration struct {
@@ -58,6 +59,7 @@ func CreateConfig() *Config {
 //				[show_details yes|true|on]
 //				[theme hacker-terminal]
 //				[refresh_frequency 2s]
+//				[ready_on_start]
 //			}
 //			blocking {
 //				[timeout 1m]
@@ -155,6 +157,9 @@ func parseDynamic(d *caddyfile.Dispenser) (*DynamicConfiguration, error) {
 				return nil, err
 			}
 			conf.RefreshFrequency = &duration
+		case "ready_on_start":
+			shouldReady := isEnabledArg(args)
+			conf.ReadyOnStart = &shouldReady
 		}
 	}
 	return conf, nil
@@ -237,6 +242,10 @@ func (c *Config) buildDynamicRequest() (*http.Request, error) {
 
 	if c.Dynamic.ShowDetails != nil {
 		q.Add("show_details", strconv.FormatBool(*c.Dynamic.ShowDetails))
+	}
+
+	if c.Dynamic.ReadyOnStart != nil {
+		q.Add("ready_on_start", strconv.FormatBool(*c.Dynamic.ReadyOnStart))
 	}
 
 	request.URL.RawQuery = q.Encode()

--- a/config_test.go
+++ b/config_test.go
@@ -139,6 +139,18 @@ func TestConfig_BuildRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "dynamic session with readyOnStart",
+			fields: caddy.Config{
+				SablierURL: "http://sablier:10000",
+				Names:      []string{"nginx"},
+				Dynamic: &caddy.DynamicConfiguration{
+					ReadyOnStart: &tru,
+				},
+			},
+			want:    createRequest("GET", "http://sablier:10000/api/strategies/dynamic?names=nginx&ready_on_start=true", nil),
+			wantErr: false,
+		},
+		{
 			name: "blocking session with required values",
 			fields: caddy.Config{
 				SablierURL: "http://sablier:10000",
@@ -249,6 +261,7 @@ func TestConfig_UnmarshalCaddyfile(t *testing.T) {
 					show_details on
 					theme hacker-terminal
 					refresh_frequency 1m
+					ready_on_start
 				}
 			}`,
 			want: caddy.Config{
@@ -260,6 +273,7 @@ func TestConfig_UnmarshalCaddyfile(t *testing.T) {
 					ShowDetails:      &tru,
 					Theme:            "hacker-terminal",
 					RefreshFrequency: &oneMinute,
+					ReadyOnStart:     &tru,
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
## What

Adds `ready_on_start` query parameter to the dynamic strategy. When `true`, Sablier returns `X-Sablier-Session-Status: ready` immediately regardless of instance health — the reverse proxy passes the request through without showing a waiting page.

The per-instance `sablier.ready-on-start` label controls behavior per container. The query param does the same, but at the middleware level — no labels needed.

## Why

Sometimes you want different behavior depending on which service is accessed:

**Home Assistant + Frigate:** When loading the HA dashboard, you want Frigate to start in the background — no need to wait. But when accessing Frigate's own UI directly, you want the waiting screen to confirm it's ready.
**Chat app + LiteLLM proxy:** When users open the chat, LiteLLM starts alongside without blocking. Direct access to LiteLLM UI get the waiting screen.

## Usage

GET /api/strategies/dynamic?group=myapp&ready_on_start=true

Plugin-side config (separate PRs):
```yaml
    frigate-sablier:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate

    frigate-sablier-force:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate
            readyOnStart: true
```