### PR TITLE
feat(config): add poke strategy directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You can have the following configuration:
 			blocking {
 				[timeout 1m]
 			}
+			poke
 		}
     reverse_proxy myservice:port
   }

--- a/config.go
+++ b/config.go
@@ -28,6 +28,9 @@ type BlockingConfiguration struct {
 	Timeout *time.Duration
 }
 
+type PokeConfiguration struct {
+}
+
 type Config struct {
 	SablierURL      string
 	Names           []string
@@ -35,6 +38,7 @@ type Config struct {
 	SessionDuration *time.Duration
 	Dynamic         *DynamicConfiguration
 	Blocking        *BlockingConfiguration
+	Poke            *PokeConfiguration
 }
 
 func CreateConfig() *Config {
@@ -44,6 +48,7 @@ func CreateConfig() *Config {
 		SessionDuration: nil,
 		Dynamic:         nil,
 		Blocking:        nil,
+		Poke:            nil,
 	}
 }
 
@@ -62,6 +67,7 @@ func CreateConfig() *Config {
 //			blocking {
 //				[timeout 1m]
 //			}
+//			poke
 //		}
 //
 func (c *Config) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -100,15 +106,26 @@ func (c *Config) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return err
 				}
 				c.Blocking = blocking
+			case "poke":
+				c.Poke = &PokeConfiguration{}
 			}
 		}
 	}
 
-	if c.Blocking == nil && c.Dynamic == nil {
-		return fmt.Errorf("you must specify one strategy (dynamic or blocking)")
+	strategyCount := 0
+	if c.Blocking != nil {
+		strategyCount++
 	}
-
-	if c.Blocking != nil && c.Dynamic != nil {
+	if c.Dynamic != nil {
+		strategyCount++
+	}
+	if c.Poke != nil {
+		strategyCount++
+	}
+	if strategyCount == 0 {
+		return fmt.Errorf("you must specify one strategy (dynamic, blocking or poke)")
+	}
+	if strategyCount > 1 {
 		return fmt.Errorf("you must specify only one strategy")
 	}
 
@@ -195,6 +212,8 @@ func (c *Config) BuildRequest() (*http.Request, error) {
 		return c.buildDynamicRequest()
 	} else if c.Blocking != nil {
 		return c.buildBlockingRequest()
+	} else if c.Poke != nil {
+		return c.buildPokeRequest()
 	}
 	return nil, fmt.Errorf("no strategy configured")
 }
@@ -270,6 +289,35 @@ func (c *Config) buildBlockingRequest() (*http.Request, error) {
 
 	if c.Blocking.Timeout != nil {
 		q.Add("timeout", c.Blocking.Timeout.String())
+	}
+
+	request.URL.RawQuery = q.Encode()
+
+	return request, nil
+}
+
+func (c *Config) buildPokeRequest() (*http.Request, error) {
+	if c.Poke == nil {
+		return nil, fmt.Errorf("poke config is nil")
+	}
+
+	request, err := http.NewRequest("GET", fmt.Sprintf("%s/api/strategies/poke", c.SablierURL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := request.URL.Query()
+
+	if c.SessionDuration != nil {
+		q.Add("session_duration", c.SessionDuration.String())
+	}
+
+	for _, name := range c.Names {
+		q.Add("names", name)
+	}
+
+	if c.Group != "" {
+		q.Add("group", c.Group)
 	}
 
 	request.URL.RawQuery = q.Encode()

--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,17 @@ func TestConfig_BuildRequest(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "poke session with names",
+			fields: caddy.Config{
+				SablierURL:      "http://sablier:10000",
+				Names:           []string{"nginx", "apache"},
+				SessionDuration: &oneMinute,
+				Poke:            &caddy.PokeConfiguration{},
+			},
+			want:    createRequest("GET", "http://sablier:10000/api/strategies/poke?names=nginx&names=apache&session_duration=1m", nil),
+			wantErr: false,
+		},
+		{
 			name: "dynamic session with required values",
 			fields: caddy.Config{
 
@@ -193,6 +204,7 @@ func TestConfig_BuildRequest(t *testing.T) {
 				SessionDuration: tt.fields.SessionDuration,
 				Dynamic:         tt.fields.Dynamic,
 				Blocking:        tt.fields.Blocking,
+				Poke:            tt.fields.Poke,
 			}
 
 			got, err := c.BuildRequest()
@@ -309,19 +321,48 @@ func TestConfig_UnmarshalCaddyfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "parse valid poke strategy",
+			input: `sablier {
+				group mygroup
+				session_duration 1m
+				poke
+			}`,
+			want: caddy.Config{
+				SablierURL:      "http://sablier:10000",
+				Group:           "mygroup",
+				SessionDuration: &oneMinute,
+				Poke:            &caddy.PokeConfiguration{},
+			},
+			wantErr: false,
+		},
+		{
 			name:  "parse invalid no strategies",
 			input: `sablier`,
 			want: caddy.Config{
 				SablierURL: "http://sablier:10000",
 			},
 			wantErr:      true,
-			wantErrValue: "you must specify one strategy (dynamic or blocking)",
+			wantErrValue: "you must specify one strategy (dynamic, blocking or poke)",
 		},
 		{
-			name: "parse invalid two strategies",
+			name: "parse invalid two strategies dynamic-blocking",
 			input: `sablier {
 				blocking 
 				dynamic
+			}`,
+			want: caddy.Config{
+				SablierURL: "http://sablier:10000",
+			},
+			wantErr:      true,
+			wantErrValue: "you must specify only one strategy",
+		},
+		{
+			name: "parse invalid two strategies poke-blocking",
+			input: `sablier {
+				poke
+				blocking {
+					timeout 1m
+				}
 			}`,
 			want: caddy.Config{
 				SablierURL: "http://sablier:10000",

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func (sm SablierMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request,
 	//nolint:errcheck
 	defer resp.Body.Close()
 
-	if resp.Header.Get("X-Sablier-Session-Status") == "ready" {
+	if resp.Header.Get("X-Sablier-Session-Status") == "ready" || sm.Config.Poke != nil {
 		return next.ServeHTTP(rw, req)
 	}
 


### PR DESCRIPTION
## What

Adds the **poke strategy** — a new `GET /api/strategies/poke` endpoint that starts instances and immediately returns `X-Sablier-Session-Status: ready`, skipping the health check. The reverse proxy passes the request through without blocking or showing a waiting page.

Useful when you want instances started but don't need them healthy before serving traffic — background workers, sidecar caches, companion processes the caller doesn't depend on.

## Usage

GET /api/strategies/poke?group=myapp&session_duration=30m

Plugin config examples (separate PRs in each plugin repo):

```yaml
# Traefik
plugin:
  sablier:
    group: myapp
    poke: {}
# Caddy
sablier {
    group mygroup
    poke
}
// Proxy-WASM
{ "group": "mygroup", "poke": {} }
```
